### PR TITLE
fix

### DIFF
--- a/Route/Router.php
+++ b/Route/Router.php
@@ -47,7 +47,7 @@ class Router {
 
                 if(isset($config->auth) && $config->auth)
                 {
-                    if(self::validation() != true)
+                    if(self::validation() == true)
                     {
                         self::runMethod($config->namespace,$config->controller,$config->action,$params);
                     }


### PR DESCRIPTION
rotas autenticadas não conseguiam seguir seu destino pois quando a sessão existia sempre entrava no else que retorna a rota de autenticação.